### PR TITLE
Update CPgsqlColumnSchema.php to support resource type

### DIFF
--- a/framework/db/schema/pgsql/CPgsqlColumnSchema.php
+++ b/framework/db/schema/pgsql/CPgsqlColumnSchema.php
@@ -31,6 +31,8 @@ class CPgsqlColumnSchema extends CDbColumnSchema
 			$this->type='double';
 		elseif(preg_match('/(integer|oid|serial|smallint)/',$dbType))
 			$this->type='integer';
+		elseif(strpos($dbType,'bytea')!==false)
+            		$this->type='resource';
 		else
 			$this->type='string';
 	}


### PR DESCRIPTION
Fixed CPgsqlColumnSchema.php to support resource type.

It is related to https://github.com/yiisoft/yii/issues/1181

When we load model with bytea column dbtype - Yii column type is "string" by default. (type of data is resource)
In this case when we trying to save this model after execution method `\CDbColumnSchema::typecast` value cast to string. And we have `Resource #2` string in database.
